### PR TITLE
Report compression update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-dashboard",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "private": true,
   "workspaces": [
     "server",

--- a/server/src/controllers/public.controller.ts
+++ b/server/src/controllers/public.controller.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from 'express';
 import { join } from 'path';
 import { APP_DIST_DIR, DASHBOARD_VERSION, BUILD_TIMESTAMP } from '@config';
-import { decodeBase64 } from '@lib/utils';
+import { decompress } from '@lib/utils';
 import * as lighthouse from '@lib/lighthouse';
 import * as reportCache from '@lib/report-cache';
 import Report from '@models/report.model';
@@ -67,13 +67,14 @@ export const serveReport: RequestHandler[] = [
 
       if (report) {
         if (typeof json !== 'undefined') {
-          const json = JSON.parse(decodeBase64(report.encodedJson));
+          const decompressedJsonStr = await decompress(report.encodedJson);
+          const json = JSON.parse(decompressedJsonStr);
 
           reportCache.save(audit, 'json', json);
 
           res.json(json);
         } else {
-          const html = decodeBase64(report.encodedHtml);
+          const html = await decompress(report.encodedHtml);
 
           reportCache.save(audit, 'html', html);
 

--- a/server/src/controllers/public.controller.ts
+++ b/server/src/controllers/public.controller.ts
@@ -84,6 +84,8 @@ export const serveReport: RequestHandler[] = [
         res.status(404).send('Report not found');
       }
     } catch (error) {
+      console.log('Error returning report');
+      console.error(error);
       res.status(404).send('Report not found');
     }
   },

--- a/server/src/lib/lighthouse/LighthouseHandler.ts
+++ b/server/src/lib/lighthouse/LighthouseHandler.ts
@@ -1,10 +1,10 @@
 import { join } from 'path';
 import { debounce } from 'lodash';
+import fetch from 'node-fetch';
 import { createLogger, createTimer, encodeBase64, delay } from '@lib/utils';
 import * as serverState from '@lib/server-state';
 import { TMP_DIR } from '@config';
 import { asyncLighthouseCommand } from './lighthouse.utils';
-import fetch from 'node-fetch';
 
 import Section from '@models/section.model';
 import PageGroup from '@models/page-group.model';
@@ -349,10 +349,11 @@ export default class LighthouseHandler {
           page: page._id,
         });
 
-        const encodedHtml = encodeBase64(result.htmlReportContent);
-        const encodedJson = encodeBase64(result.jsonReportContent);
-
-        await Report.create({ audit: auditDoc._id, encodedHtml, encodedJson });
+        await Report.create({
+          audit: auditDoc._id,
+          encodedHtml: result.htmlReportContent,
+          encodedJson: result.jsonReportContent,
+        });
 
         const audit: Lhd.Audit = {
           _id: auditDoc._id.toHexString(),

--- a/server/src/lib/lighthouse/lighthouse.utils.ts
+++ b/server/src/lib/lighthouse/lighthouse.utils.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'child_process';
 import { join } from 'path';
 import * as filesize from 'filesize';
 import {
@@ -12,7 +11,7 @@ import {
   WriteStream,
 } from 'fs';
 import { TMP_DIR, ROOT_DIR, VERBOSE_LIGHTHOUSE_LOGGING } from '@config';
-import { createTimer, parseToLines } from '@lib/utils';
+import { createTimer, parseToLines, compress, spawnAsync } from '@lib/utils';
 
 /**
  * CPU Throttle value calculation
@@ -78,52 +77,58 @@ type LighthouseCommandConfig = {
   logFile?: string;
 };
 
-export const asyncLighthouseCommand = ({
+export const asyncLighthouseCommand = async ({
   url,
   cpuThrottle = 1,
   onLogEvent: emitLog = () => {},
   logFile,
-}: LighthouseCommandConfig): Promise<LighthouseOutput | null> =>
-  new Promise((resolve) => {
-    // Ensure tmp dir
-    if (!existsSync(TMP_DIR)) {
-      mkdirSync(TMP_DIR);
-    }
+}: LighthouseCommandConfig): Promise<LighthouseOutput | null> => {
+  // Ensure tmp dir
+  if (!existsSync(TMP_DIR)) {
+    mkdirSync(TMP_DIR);
+  }
 
-    let logFileStream: WriteStream;
+  let logFileStream: WriteStream;
 
-    if (logFile) {
-      // Ensure empty logfile on start
-      writeFileSync(logFile, '');
+  if (logFile) {
+    // Ensure empty logfile on start
+    writeFileSync(logFile, '');
 
-      logFileStream = createWriteStream(logFile, { flags: 'a' });
-    }
+    logFileStream = createWriteStream(logFile, { flags: 'a' });
+  }
 
-    // Wrapper function for logging and emitting output
-    const log = (lines: string[], verbose = true) => {
-      emitLog(lines, verbose);
-      logFileStream && logFileStream.write(`${lines.join('\n')}\n`);
-    };
+  // Wrapper function for logging and emitting output
+  const log = (lines: string[], verbose = true) => {
+    emitLog(lines, verbose);
+    logFileStream && logFileStream.write(`${lines.join('\n')}\n`);
+  };
 
-    const logPrefix = () => `${new Date().toUTCString()} Info:`;
+  const logPrefix = () => `${new Date().toUTCString()} Info:`;
 
-    // Set timer
-    const getTimePassed = createTimer();
+  // Set timer
+  const getTimePassed = createTimer();
 
-    log([
-      `${logPrefix()} Starting audit on ${url}`,
-      `${logPrefix()} CPU throttle set to ${cpuThrottle.toFixed(1)}`,
-    ]);
-    log(['----'], VERBOSE_LIGHTHOUSE_LOGGING);
+  log([
+    `${logPrefix()} Starting audit on ${url}`,
+    `${logPrefix()} CPU throttle set to ${cpuThrottle.toFixed(1)}`,
+  ]);
+  log(['----'], VERBOSE_LIGHTHOUSE_LOGGING);
 
-    // Temporary report file name
-    const tempFileName = join(TMP_DIR, `temp-report_${new Date().getTime()}`);
+  // Temporary report file name
+  const tempFileName = join(TMP_DIR, `temp-report_${new Date().getTime()}`);
 
-    // Lighthouse bin file
-    const lighthouseBin = join(ROOT_DIR, 'node_modules/.bin/lighthouse');
+  // Lighthouse bin file
+  const lighthouseBin = join(ROOT_DIR, 'node_modules/.bin/lighthouse');
 
-    // Run Lighthouse command process
-    const lh = spawn(lighthouseBin, [
+  // Callback functions for stdout and stderr
+  const catchSpawnOutputs = (data: Buffer) => {
+    const lines = parseToLines(data);
+    log(lines, VERBOSE_LIGHTHOUSE_LOGGING);
+  };
+
+  // Execute Lighthouse command asynchronously
+  await spawnAsync(lighthouseBin, {
+    args: [
       url,
       '--output=json,html',
       `--output-path=${tempFileName}`,
@@ -131,86 +136,90 @@ export const asyncLighthouseCommand = ({
       '--chrome-flags="--headless --no-sandbox --disable-dev-shm-usage --disable-gpu"',
       '--verbose',
       `--throttling.cpuSlowdownMultiplier=${cpuThrottle.toFixed(1)}`,
+    ],
+    onStdOutData: catchSpawnOutputs,
+    onStdErrData: catchSpawnOutputs,
+  });
+
+  log(['----'], VERBOSE_LIGHTHOUSE_LOGGING);
+  log([`${logPrefix()} Lighthouse run completed!`]);
+
+  try {
+    log([`${logPrefix()} Loading generated HTML and JSON report files ...`]);
+
+    // Read temporary report files
+    const jsonReportContent = readFileSync(
+      `${tempFileName}.report.json`,
+      'utf8'
+    );
+    const htmlReportContent = readFileSync(
+      `${tempFileName}.report.html`,
+      'utf8'
+    );
+
+    log([`${logPrefix()} Cleaning up temporary files ...`]);
+
+    // Delete temporary report files
+    readdirSync(TMP_DIR).forEach((fileName) => {
+      if (/\.report\.(json|html)$/.test(fileName)) {
+        unlinkSync(join(TMP_DIR, fileName));
+      }
+    });
+
+    log([`${logPrefix()} Parsing generated JSON report file content ...`]);
+
+    const data = JSON.parse(jsonReportContent);
+
+    const score = {
+      performance: data.categories.performance.score,
+      accessibility: data.categories.accessibility.score,
+      bestPractices: data.categories['best-practices'].score,
+      seo: data.categories.seo.score,
+    };
+
+    // Compress JSON and HTML reports
+    const jsonCompressed = await compress(jsonReportContent);
+    const htmlCompressed = await compress(htmlReportContent);
+
+    // Get data sizes
+    const jsonInputSize = Buffer.byteLength(jsonReportContent);
+    const jsonOutputSize = Buffer.byteLength(jsonCompressed);
+    const htmlInputSize = Buffer.byteLength(htmlReportContent);
+    const htmlOutputSize = Buffer.byteLength(htmlCompressed);
+
+    log([
+      '----',
+      `${logPrefix()} Score ${JSON.stringify(score, null, 2)}`,
+      `${logPrefix()} JSON report size ${filesize(jsonInputSize)} (${filesize(
+        jsonOutputSize
+      )} compressed)`,
+      `${logPrefix()} HTML report size ${filesize(htmlInputSize)} (${filesize(
+        htmlOutputSize
+      )} compressed)`,
     ]);
 
-    lh.stdout.on('data', (data: Buffer) => {
-      const lines = parseToLines(data);
-      log(lines, VERBOSE_LIGHTHOUSE_LOGGING);
-    });
+    log([
+      '----',
+      `${logPrefix()} Audit finished after ${getTimePassed() / 1000}s`,
+    ]);
 
-    lh.stderr.on('data', (data: Buffer) => {
-      const lines = parseToLines(data);
-      log(lines, VERBOSE_LIGHTHOUSE_LOGGING);
-    });
+    logFileStream?.end();
 
-    lh.on('close', () => {
-      log(['----'], VERBOSE_LIGHTHOUSE_LOGGING);
-      log([`${logPrefix()} Lighthouse run completed!`]);
+    return {
+      score,
+      jsonReportContent: jsonCompressed,
+      htmlReportContent: htmlCompressed,
+    };
+  } catch (error) {
+    log([
+      '----',
+      `${logPrefix()} Audit failed after ${getTimePassed() / 1000}s`,
+      'Error:',
+      error.toString(),
+    ]);
 
-      try {
-        log([
-          `${logPrefix()} Loading generated HTML and JSON report files ...`,
-        ]);
+    logFileStream?.end();
+  }
 
-        // Read temporary report files
-        const jsonReportContent = readFileSync(
-          `${tempFileName}.report.json`,
-          'utf8'
-        );
-        const htmlReportContent = readFileSync(
-          `${tempFileName}.report.html`,
-          'utf8'
-        );
-
-        log([`${logPrefix()} Cleaning up temporary files ...`]);
-
-        // Delete temporary report files
-        readdirSync(TMP_DIR).forEach((fileName) => {
-          if (/\.report\.(json|html)$/.test(fileName)) {
-            unlinkSync(join(TMP_DIR, fileName));
-          }
-        });
-
-        log([`${logPrefix()} Parsing generated JSON report file content ...`]);
-
-        const data = JSON.parse(jsonReportContent);
-
-        const score = {
-          performance: data.categories.performance.score,
-          accessibility: data.categories.accessibility.score,
-          bestPractices: data.categories['best-practices'].score,
-          seo: data.categories.seo.score,
-        };
-
-        const jsonBytes = Buffer.byteLength(jsonReportContent, 'utf8');
-        const htmlBytes = Buffer.byteLength(htmlReportContent, 'utf8');
-
-        log([
-          '----',
-          `${logPrefix()} score ${JSON.stringify(score, null, 2)}`,
-          `${logPrefix()} JSON report size ${filesize(jsonBytes)}`,
-          `${logPrefix()} HTML report size ${filesize(htmlBytes)}`,
-        ]);
-
-        log([
-          '----',
-          `${logPrefix()} Audit finished after ${getTimePassed() / 1000}s`,
-        ]);
-
-        logFileStream?.end();
-
-        return resolve({ score, jsonReportContent, htmlReportContent });
-      } catch (error) {
-        log([
-          '----',
-          `${logPrefix()} Audit failed after ${getTimePassed() / 1000}s`,
-          'Error:',
-          error.toString(),
-        ]);
-
-        logFileStream?.end();
-      }
-
-      resolve(null);
-    });
-  });
+  return null;
+};

--- a/server/src/lib/utils.ts
+++ b/server/src/lib/utils.ts
@@ -100,9 +100,17 @@ export const parseToLines = (data: unknown): string[] =>
 export const compress = (input: string) =>
   new Promise<string>((resolve, reject) => {
     deflate(input, { level: 9 }, (err, buffer) => {
-      if (err) reject();
+      if (err) return reject(err);
 
-      resolve(buffer.toString('base64'));
+      let bufferStr: string;
+
+      try {
+        bufferStr = buffer.toString('utf8');
+      } catch (error) {
+        reject(error);
+      }
+
+      resolve(bufferStr);
     });
   });
 
@@ -111,10 +119,20 @@ export const compress = (input: string) =>
  */
 export const decompress = (input: string) =>
   new Promise<string>((resolve, reject) => {
-    inflate(Buffer.from(input, 'base64'), (err, buffer) => {
-      if (err) reject();
+    const compressedBuffer = Buffer.from(input, 'base64');
 
-      resolve(buffer.toString('utf8'));
+    inflate(compressedBuffer, (err, buffer) => {
+      if (err) return reject(err);
+
+      let bufferStr: string;
+
+      try {
+        bufferStr = buffer.toString('utf8');
+      } catch (error) {
+        reject(error);
+      }
+
+      resolve(bufferStr);
     });
   });
 


### PR DESCRIPTION
Added compression to HTML and JSON reports before saving them to the database, since they were getting a bit big. This however is a breaking change of sort, as there's no backwards compatibility for reports created before this update.

- HTML and JSON reports generated by Lighthouse will now be compressed before saving to the database
- Refactored Lighthouse command function to be a async function instead of returning a Promise.